### PR TITLE
Explicitly set the compression algorithm

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -2,12 +2,12 @@ name: Build deb package
 
 on:
   push:
-    branches: [ 6826-autostream ]
+    branches: [ fosdem ]
 
 env:
   # Java version to use for the release
   RELEASE_JAVA_VERSION: 8
-  BUILD_NUMBER: 6826-autostream
+  BUILD_NUMBER: 8218-autostream
 
 jobs:
   build:

--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,9 @@
 override_dh_auto_clean:
 	mvn -Dmaven.repo.local=${HOME}/.m2/repository clean
 
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip
+
 override_dh_auto_configure:
 	# do nothing
 


### PR DESCRIPTION
Previously we were running `dpkg-buildpackage` to build the deb package. This job is running on a GHA on `ubuntu-latest`, Ubuntu now defaults to `zst` instead of `gzip` since last year. `zst` is not yet supported by Debian. The `jicofo` image is based on Debian Bullseye